### PR TITLE
Removed misleading doc.

### DIFF
--- a/ment.io/index.html
+++ b/ment.io/index.html
@@ -351,7 +351,7 @@
                 typed term after the trigger char is bound as the <code>term</code> argument in the expression.
                 <p></p>
                 The implementation of the search function should populate the data collection referenced by the <code>mentio-items</code>
-                attribute with data.  The scope property referenced by <code>items</code> can be a promise.  No return is expected from
+                attribute with data.  No return is expected from
                 the search fucntion.
                 <p></p>
                 If no search function is specified, the list of objects in <code>mentio-items</code> will 


### PR DESCRIPTION
I removed this line from the doc for mentio-search:

```
The scope property referenced by <code>items</code> can be a promise.
```

In fact, it cannot be a promise. If you try setting it to a promise, the
template will try to iterate over it. Instead, the mentio-search function should
just set the items property as soon as it has it.

The only promise-related code in mentio is for mentio-select, not mentio-search.
