### PR TITLE
Define 'main' property in bower.json.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "ment.io",
   "version": "0.9.15",
+  "main": "dist/mentio.js",
   "homepage": "https://github.com/jeff-collins/ment.io",
   "authors": [
     "jeff-collins <i.am.jeff.collins@gmail.com>",


### PR DESCRIPTION
Without the 'main' property, the bower-install Grunt task will give the
following warning, and will remove mentio.js from the bower:js section of your
html file:

```
Running "bower-install:app" (bower-install) task

ment.io was not injected in your file.
Please go take a look in "src/bower_components/ment.io" for the file you need, then manually include it in your file.
```

See http://stackoverflow.com/questions/21892016/bower-throws-jquery-not-injected-warning-after-running-grunt-serve :

```
This isn't an error with grunt-bower-install - this is, sadly, jQuery not
playing by Bower's rules. It's not possible for this tool to work with a
Bower package that doesn't specify main property. Like any other package
that doesn't, the solution is to manually include the reference to the file
inside of your HTML file, like the good ol' days
```
