### PR TITLE
Prevent propagation of the click event on menu items

### DIFF
--- a/src/mentio.directive.js
+++ b/src/mentio.directive.js
@@ -609,6 +609,7 @@ angular.module('mentio', [])
                 element.bind('click', function (e) {
                     e.preventDefault();
                     controller.selectItem(scope.item);
+                    return false;
                 });
             }
         };


### PR DESCRIPTION
I am having an issue where clicking on the menu item is propagating outside of mentions.  Since the directive creates and handles all events on the menu item, it seems safe to stop propagation here.