### PR TITLE
Removing superfluous preventDefault call

### DIFF
--- a/src/mentio.directive.js
+++ b/src/mentio.directive.js
@@ -607,7 +607,6 @@ angular.module('mentio', [])
                 });
 
                 element.bind('click', function (e) {
-                    e.preventDefault();
                     controller.selectItem(scope.item);
                     return false;
                 });


### PR DESCRIPTION
Follow-up on https://github.com/jeff-collins/ment.io/pull/63

Since `return false` effectively does both `ev.preventDefault()` and `ev.stopPropagation()` we can now remove this line.  (http://stackoverflow.com/questions/1357118/event-preventdefault-vs-return-false)