### PR TITLE
Expose menuItem.isVisible to the controller

### DIFF
--- a/src/mentio.directive.js
+++ b/src/mentio.directive.js
@@ -520,7 +520,8 @@ angular.module('mentio', [])
                     $scope.selectItem($scope.activeItem);
                 };
 
-                $scope.isVisible = function () {
+                // callable both with controller (menuItem) and without controller (local)
+                this.isVisible = $scope.isVisible = function () {
                     return $scope.visible;
                 };
 


### PR DESCRIPTION
I needed a way to detect if the ```mentioMenu``` was visible or not. You already had a method for that in your controller and you're already exposing ```isActive()``` and a few other methods in this way, so I added the ```this.isVisible``` assignment.