### PR TITLE
Allow trigger characters inside a term, if leading space is required.

### DIFF
--- a/src/mentio.service.js
+++ b/src/mentio.service.js
@@ -320,6 +320,7 @@ angular.module('mentio')
                     if (requireLeadingSpace) {
                         idx = Math.max(
                             effectiveRange.lastIndexOf(' ' + c),
+                            effectiveRange.lastIndexOf('\n' + c),
                             effectiveRange.lastIndexOf('\xA0' + c));
                         if (idx < 0) {
                             idx = effectiveRange && effectiveRange.charAt(0) === c ? 0 : -1;
@@ -343,6 +344,7 @@ angular.module('mentio')
                     var leadingSpace = currentTriggerSnippet.length > 0 &&
                         (
                             firstSnippetChar === ' ' ||
+                            firstSnippetChar === '\n' ||
                             firstSnippetChar === '\xA0'
                         );
                     if (hasTrailingSpace) {

--- a/src/mentio.service.js
+++ b/src/mentio.service.js
@@ -316,25 +316,22 @@ angular.module('mentio')
                 var mostRecentTriggerCharPos = -1;
                 var triggerChar;
                 triggerCharSet.forEach(function(c) {
-                    var idx = effectiveRange.lastIndexOf(c);
+                    var idx;
+                    if (requireLeadingSpace) {
+                        idx = Math.max(
+                            effectiveRange.lastIndexOf(' ' + c),
+                            effectiveRange.lastIndexOf('\xA0' + c),
+                            effectiveRange && effectiveRange.charAt(0) === c ? 0 : -1
+                        );
+                    } else {
+                        idx = effectiveRange.lastIndexOf(c);
+                    }
                     if (idx > mostRecentTriggerCharPos) {
                         mostRecentTriggerCharPos = idx;
                         triggerChar = c;
                     }
                 });
-                if (mostRecentTriggerCharPos >= 0 &&
-                        (
-                            mostRecentTriggerCharPos === 0 ||
-                            !requireLeadingSpace ||
-                            /[\xA0\s]/g.test
-                            (
-                                effectiveRange.substring(
-                                    mostRecentTriggerCharPos - 1,
-                                    mostRecentTriggerCharPos)
-                            )
-                        )
-                    )
-                {
+                if (mostRecentTriggerCharPos >= 0) {
                     var currentTriggerSnippet = effectiveRange.substring(mostRecentTriggerCharPos + 1,
                         effectiveRange.length);
 

--- a/src/mentio.service.js
+++ b/src/mentio.service.js
@@ -174,7 +174,7 @@ angular.module('mentio')
         }
 
         // public
-        function replaceTriggerText (ctx, targetElement, path, offset, triggerCharSet, 
+        function replaceTriggerText (ctx, targetElement, path, offset, triggerCharSet,
                 text, requireLeadingSpace, hasTrailingSpace) {
             resetSelection(ctx, targetElement, path, offset);
 
@@ -297,7 +297,7 @@ angular.module('mentio')
         // public
         function getTriggerInfo (ctx, triggerCharSet, requireLeadingSpace, menuAlreadyActive, hasTrailingSpace) {
             /*jshint maxcomplexity:11 */
-            // yes this function needs refactoring 
+            // yes this function needs refactoring
             var selected, path, offset;
             if (selectedElementIsTextAreaOrInput(ctx)) {
                 selected = getDocument(ctx).activeElement;
@@ -320,9 +320,12 @@ angular.module('mentio')
                     if (requireLeadingSpace) {
                         idx = Math.max(
                             effectiveRange.lastIndexOf(' ' + c),
-                            effectiveRange.lastIndexOf('\xA0' + c),
-                            effectiveRange && effectiveRange.charAt(0) === c ? 0 : -1
-                        );
+                            effectiveRange.lastIndexOf('\xA0' + c));
+                        if (idx < 0) {
+                            idx = effectiveRange && effectiveRange.charAt(0) === c ? 0 : -1;
+                        } else {
+                            idx++;
+                        }
                     } else {
                         idx = effectiveRange.lastIndexOf(c);
                     }
@@ -443,7 +446,7 @@ angular.module('mentio')
                     obj = iframe;
                     iframe = null;
                 }
-            }            
+            }
         }
 
         function getTextAreaOrInputUnderlinePosition (ctx, element, position) {


### PR DESCRIPTION
As long as a leading space is required, a trigger character without a leading space should be able to be used inside a term since there's no ambiguity.  This patch moves the leading space detection earlier in the algorithm, so that triggers without a leading space aren't even considered.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jeff-collins/ment.io/91)

<!-- Reviewable:end -->
