### PR TITLE
Don't listen for keypress and paste, event.which is meaningless for them

### DIFF
--- a/src/mentio.directive.js
+++ b/src/mentio.directive.js
@@ -205,40 +205,41 @@ angular.module('mentio', [])
                 );
 
                 $document.on(
-                    'keydown keypress paste', function (event) {
+                    'keydown', function (event) {
                         var activeMenuScope = $scope.getActiveMenuScope();
-                        if (activeMenuScope) {
-                            if (event.which === 9 || event.which === 13) {
+                        if (!activeMenuScope) return;
+                        switch (event.which) {
+                            case 9: case 13:
                                 event.preventDefault();
                                 activeMenuScope.selectActive();
-                            }
+                                break;
 
-                            if (event.which === 27) {
+                            case 27:
                                 event.preventDefault();
                                 activeMenuScope.$apply(function () {
                                     activeMenuScope.hideMenu();
                                 });
-                            }
+                                break;
 
-                            if (event.which === 40) {
+                            case 40:
                                 event.preventDefault();
                                 activeMenuScope.$apply(function () {
                                     activeMenuScope.activateNextItem();
                                 });
                                 activeMenuScope.adjustScroll(1);
-                            }
+                                break;
 
-                            if (event.which === 38) {
+                            case 38:
                                 event.preventDefault();
                                 activeMenuScope.$apply(function () {
                                     activeMenuScope.activatePreviousItem();
                                 });
                                 activeMenuScope.adjustScroll(-1);
-                            }
+                                break;
 
-                            if (event.which === 37 || event.which === 39) {
+                            case 37: case 39:
                                 event.preventDefault();
-                             }
+                                break;
                         }
                     }
                 );
@@ -288,43 +289,39 @@ angular.module('mentio', [])
                         event.stopImmediatePropagation();
                     }
                     var activeMenuScope = scope.getActiveMenuScope();
-                    if (activeMenuScope) {
-                        if (event.which === 9 || event.which === 13) {
+                    if (!activeMenuScope) return;
+                    switch (event.which) {
+                        case 9: case 13:
                             stopEvent(event);
                             activeMenuScope.selectActive();
                             return false;
-                        }
 
-                        if (event.which === 27) {
+                        case 27:
                             stopEvent(event);
                             activeMenuScope.$apply(function () {
                                 activeMenuScope.hideMenu();
                             });
                             return false;
-                        }
 
-                        if (event.which === 40) {
+                        case 40:
                             stopEvent(event);
                             activeMenuScope.$apply(function () {
                                 activeMenuScope.activateNextItem();
                             });
                             activeMenuScope.adjustScroll(1);
                             return false;
-                        }
 
-                        if (event.which === 38) {
+                        case 38:
                             stopEvent(event);
                             activeMenuScope.$apply(function () {
                                 activeMenuScope.activatePreviousItem();
                             });
                             activeMenuScope.adjustScroll(-1);
                             return false;
-                        }
 
-                        if (event.which === 37 || event.which === 39) {
+                        case 37: case 39:
                             stopEvent(event);
                             return false;
-                        }
                     }
                 }
 


### PR DESCRIPTION
I'm not sure why the code was listening for `keypress` and `paste`: the latter doesn't have a `which` attribute (at least not documented), and the former's `which` attribute is set to the ASCII code of the key, not the key code, which makes inputting `(` be treated as cursor down.

I also replaced the `if` series with a `switch`, as I think it's more readable (and perhaps marginally more efficient).