### PR TITLE
Escape HTML when highlighting query in a result.

### DIFF
--- a/src/mentio.directive.js
+++ b/src/mentio.directive.js
@@ -666,13 +666,17 @@ angular.module('mentio', [])
         function escapeRegexp (queryToEscape) {
             return queryToEscape.replace(/([.?*+^$[\]\\(){}|-])/g, '\\$1');
         }
+        function escapeHtml (stringToEscape) {
+            return stringToEscape.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        }
 
         return function (matchItem, query, hightlightClass) {
+            matchItem = escapeHtml('' + matchItem);
             if (query) {
                 var replaceText = hightlightClass ?
                                  '<span class="' + hightlightClass + '">$&</span>' :
                                  '<strong>$&</strong>';
-                return ('' + matchItem).replace(new RegExp(escapeRegexp(query), 'gi'), replaceText);
+                return matchItem.replace(new RegExp(escapeRegexp(escapeHtml(query)), 'gi'), replaceText);
             } else {
                 return matchItem;
             }


### PR DESCRIPTION
Since the results of `mentio-highlight` are passed to `ng-bind-html`, it's important to escape the text we're decorating otherwise we can end up with invalid HTML and a `$sanitize:badparse` error.