### PR TITLE
Fix shortcut BUG up/down and &/( have same event.which/keyCode

### DIFF
--- a/src/mentio.directive.js
+++ b/src/mentio.directive.js
@@ -202,14 +202,14 @@ angular.module('mentio', [])
                                 });
                             }
 
-                            if (event.which === 40) {
+                            if (event.which === 40 && !event.shiftKey) {
                                 event.preventDefault();
                                 activeMenuScope.$apply(function () {
                                     activeMenuScope.activateNextItem();
                                 });
                             }
 
-                            if (event.which === 38) {
+                            if (event.which === 38 && !event.shiftKey) {
                                 event.preventDefault();
                                 activeMenuScope.$apply(function () {
                                     activeMenuScope.activatePreviousItem();


### PR DESCRIPTION
I used  ment.io for emoji suggestion (and set `:` as the trigger), when I try to type a `:(` , the `(` always to active next item. 

Keycode of `(` is same as  `down arrow``s.(`&` and `up arrow` too)
 https://msdn.microsoft.com/en-us/magazine/ff928319