### PR TITLE
Using different property instead of "label"

### DIFF
--- a/src/mentio.directive.js
+++ b/src/mentio.directive.js
@@ -16,7 +16,8 @@ angular.module('mentio', [])
                 requireLeadingSpace: '=mentioRequireLeadingSpace',
                 selectNotFound: '=mentioSelectNotFound',
                 trimTerm: '=mentioTrimTerm',
-                ngModel: '='
+                ngModel: '=',
+                labelProp: '@mentioLabelProp'
             },
             controller: function($scope, $timeout, $attrs) {
 
@@ -39,6 +40,7 @@ angular.module('mentio', [])
                 $scope.defaultSearch = function(locals) {
                     var results = [];
                     angular.forEach($scope.items, function(item) {
+                        item.label = item[$scope.labelProp];
                         if (item.label.toUpperCase().indexOf(locals.term.toUpperCase()) >= 0) {
                             results.push(item);
                         }


### PR DESCRIPTION
With this simple workaround you can set a property mentio-label-prop on mentio directive and It will be used instead of label.

es: 
`<textarea mentio mentio-label-prop="name" 
mentio-typed-text="typedTerm" mentio-items="items | filter:name:typedTerm"></textarea>`