### PR TITLE
check for content window in the newvalue

### DIFF
--- a/src/mentio.directive.js
+++ b/src/mentio.directive.js
@@ -330,7 +330,7 @@ angular.module('mentio', [])
 
                 scope.$watch(
                     'iframeElement', function(newValue) {
-                        if (newValue) {
+                        if (newValue && newValue.contentWindow) {
                             var iframeDocument = newValue.contentWindow.document;
                             iframeDocument.addEventListener('click',
                                 function () {


### PR DESCRIPTION
Fix to Issue - #209
https://github.com/jeff-collins/ment.io/issues/209

We have added the check here because sometimes the content window value is null, which throws an error in the console.

![image](https://user-images.githubusercontent.com/46880667/65147228-5544ab00-da3b-11e9-9b3c-d455a0776c98.png)
